### PR TITLE
Add non-blocking capability with --tx-carrier

### DIFF
--- a/src/minimodem.1.in
+++ b/src/minimodem.1.in
@@ -187,6 +187,10 @@ Filter the received text output, replacing any "non-printable" bytes
 with a '.' character.
 (This option applies to \-\-rx mode only).
 .TP
+.B \-\-tx-carrier
+When transmitting from a blocking source, keep a carrier going while waiting
+for more data.
+.TP
 .B \-\-benchmarks
 Run and report internal performance tests (all other flags are ignored).
 .TP

--- a/src/simpleaudio-alsa.c
+++ b/src/simpleaudio-alsa.c
@@ -155,7 +155,7 @@ sa_alsa_open_stream(
 		channels,
 		rate,
 		1 /* soft_resample (allow) */,
-		(unsigned int)-1 /* latency (allow max to avoid underruns) */);
+		100000 /* latency (us) */);
     if (error) {
 	fprintf(stderr, "E: %s\n", snd_strerror(error));
 	snd_pcm_close(pcm);


### PR DESCRIPTION
I've added a non-blocking capability, using read() in place of getchar(), and using select() to check whether there is data on the input.  This means a carrier tone can persist on the line if desired, even when waiting for input data.

To cope with the 'idle' line state, I've used a value of 2 in tx_transmitting to signal that the preamble has been set, where 1 now reflects that the carrier has been present for the necessary time.  This enables sync bytes to be sent before actual data, even when the carrier is being transmitted.