### PR TITLE
install dependencies script & Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: c
+os:
+  - linux
+  - osx
+env:
+  - HOMEBREW_NO_INSTALL_CLEANUP=true
+install:
+  - if [ $TRAVIS_OS_NAME == 'linux' ]; then ./install-dependencies-linux.sh; fi
+  - if [ $TRAVIS_OS_NAME == 'osx' ]; then ./install-dependencies-macos.sh; fi
+script:
+  - autoreconf -i
+  - if [ $TRAVIS_OS_NAME == 'linux' ]; then ./configure; fi
+  - if [ $TRAVIS_OS_NAME == 'osx' ]; then ./configure --without-alsa --without-pulseaudio; fi
+  - make
+  - ./src/minimodem --benchmarks

--- a/install-dependencies-linux.sh
+++ b/install-dependencies-linux.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+set -x
+set -o pipefail
+
+sudo apt install libsndfile1-dev fftw3-dev libasound2-dev libpulse-dev
+sudo apt install pkg-config automake

--- a/install-dependencies-linux.sh
+++ b/install-dependencies-linux.sh
@@ -3,5 +3,6 @@ set -e
 set -x
 set -o pipefail
 
+sudo apt update
 sudo apt install libsndfile1-dev fftw3-dev libasound2-dev libpulse-dev
 sudo apt install pkg-config automake

--- a/install-dependencies-macos.sh
+++ b/install-dependencies-macos.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+set -x
+set -o pipefail
+
+brew install libsndfile fftw
+brew install automake

--- a/install-dependencies-macos.sh
+++ b/install-dependencies-macos.sh
@@ -4,4 +4,4 @@ set -x
 set -o pipefail
 
 brew install libsndfile fftw
-brew install automake
+brew install automake || brew upgrade automake


### PR DESCRIPTION
Thanks for this project!

This PR intends to
- make it easier to build `minimodem` locally by adding the `install-dependencies-linux.sh` & `install-dependencies-macos` scripts,
- show up front that this project currently has a working build by adding Travis CI,
- lowers the barrier of contributing a bit by letting Travis CI build PRs.

When merging this, you would have to activate Travis CI for this repo over at https://travis-ci.org/profile/kamalmostafa