### PR TITLE
Added UnSift on Space (USOS) for baudot as an option

### DIFF
--- a/src/baudot.c
+++ b/src/baudot.c
@@ -196,6 +196,11 @@ baudot_encode_table[0x60][2] = {
  */
 static unsigned int baudot_charset = 0;		// FIXME
 
+/*
+ * UnShift on space
+ */
+unsigned int baudot_usos = 1;
+
 
 void
 baudot_reset()
@@ -222,7 +227,7 @@ baudot_decode( char *char_outp, unsigned char databits )
     } else if ( databits == BAUDOT_LTRS ) {
 	baudot_charset = 1;
 	stuff_char = 0;
-    } else if ( databits == BAUDOT_SPACE ) {	/* RX un-shift on space */
+    } else if ( databits == BAUDOT_SPACE && baudot_usos ) {	/* RX un-shift on space */
 	baudot_charset = 1;
     }
     if ( stuff_char ) {
@@ -299,7 +304,7 @@ baudot_encode( unsigned int *databits_outp, char char_out )
     databits_outp[n++] = baudot_encode_table[ind][0];
 
     /* TX un-shift on space */
-    if ( char_out == ' ' )
+    if ( char_out == ' ' && baudot_usos )
 	baudot_charset = 1;
 
     return n;

--- a/src/baudot.h
+++ b/src/baudot.h
@@ -17,6 +17,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+extern int baudot_usos;
 
 void
 baudot_reset();

--- a/src/minimodem.1.in
+++ b/src/minimodem.1.in
@@ -117,6 +117,13 @@ ASCII  8\-N\-1
 .B \-5, \-\-baudot
 Baudot 5\-N\-1.5
 .TP
+.B \-u, \-\-usos {0|1} (default: 1)
+Enable or disable USOS (UnShift on Space) for baudot. USOS is a
+convention whereby a SPACE also implies a switch to LETTERS character
+set.  This switch can be used to disable USOS so that streams not
+adhering to this convention can be decoded correctly (e.g. German
+DWD's RTTY maritime weather report and forecast).
+.TP
 .B \-f, \-\-file filename.wav
 encode or decode an audio file (extension sets audio format)
 .TP

--- a/src/minimodem.c
+++ b/src/minimodem.c
@@ -42,6 +42,7 @@
 #include "simpleaudio.h"
 #include "fsk.h"
 #include "databits.h"
+#include "baudot.h"
 
 char *program_name = "";
 
@@ -401,6 +402,7 @@ usage()
     "		    -8, --ascii		ASCII  8-N-1\n"
     "		    -7,			ASCII  7-N-1\n"
     "		    -5, --baudot	Baudot 5-N-1\n"
+    "		    -u, --usos {0|1}\n"
     "		    -f, --file {filename.flac}\n"
     "		    -b, --bandwidth {rx_bandwidth}\n"
     "		    -v, --volume {amplitude or 'E'}\n"
@@ -601,6 +603,7 @@ main( int argc, char*argv[] )
 	    { "ascii",		0, 0, '8' },
 	    { "",		0, 0, '7' },
 	    { "baudot",		0, 0, '5' },
+	    { "usos",  		1, 0, 'u' },
 	    { "msb-first",	0, 0, MINIMODEM_OPT_MSBFIRST },
 	    { "file",		1, 0, 'f' },
 	    { "bandwidth",	1, 0, 'b' },
@@ -626,7 +629,7 @@ main( int argc, char*argv[] )
 	    { "tx-carrier",      0, 0, MINIMODEM_OPT_TXCARRIER },
 	    { 0 }
 	};
-	c = getopt_long(argc, argv, "Vtrc:l:ai875f:b:v:M:S:T:qA::R:",
+	c = getopt_long(argc, argv, "Vtrc:l:ai875u:f:b:v:M:S:T:qA::R:",
 		long_options, &option_index);
 	if ( c == -1 )
 	    break;
@@ -669,6 +672,9 @@ main( int argc, char*argv[] )
 			bfsk_n_data_bits = 5;
 			bfsk_databits_decode = databits_decode_baudot;
 			bfsk_databits_encode = databits_encode_baudot;
+			break;
+	    case 'u':
+			baudot_usos = atoi(optarg);
 			break;
 	    case MINIMODEM_OPT_MSBFIRST:
 			bfsk_msb_first = 1;


### PR DESCRIPTION
Hi Kamal

Here is my modest contribution to minimodem. It makes USOS for baudot optional so that messages not adhering to the convention can be decoded correctly.

Hope you're happy to merge it.

Regards
Richard Hacker 