### PR TITLE
Using a Goertzel filter instead of using the fft

### DIFF
--- a/src/fsk.h
+++ b/src/fsk.h
@@ -19,7 +19,8 @@
 
 
 
-#define USE_FFT		// leave this enabled; its presently the only choice
+//#define USE_FFT		// leave this enabled; its presently the only choice
+#define USE_GOERTZEL
 
 #ifdef USE_FFT
 #include <fftw3.h>
@@ -43,6 +44,14 @@ struct fsk_plan {
 	float		*fftin;
 	fftwf_complex	*fftout;
 #endif
+
+#ifdef USE_GOERTZEL
+	unsigned int	nbands;
+	float		band_width;
+	int		fftsize;
+	float		*fftin;
+#endif
+
 };
 
 

--- a/src/minimodem.c
+++ b/src/minimodem.c
@@ -1206,6 +1206,7 @@ main( int argc, char*argv[] )
 		b_shift *= -1;
 	    /* only accept a carrier as b_mark if it will not result
 	     * in a b_space band which is "too low". */
+
 	    int b_space = carrier_band + b_shift;
 	    if ( b_space < 1 || b_space >= fskp->nbands ) {
 		debug_log("autodetected space band out of range\n" );
@@ -1337,11 +1338,21 @@ main( int argc, char*argv[] )
 		if ( bfsk_data_rate >= 100 )
 		    fprintf(stderr, "### CARRIER %u @ %.1f Hz ",
 			    (unsigned int)(bfsk_data_rate + 0.5f),
+#ifdef USE_FFT
 			    (double)(fskp->b_mark * fskp->band_width));
+#endif
+#ifdef USE_GOERTZEL
+			    (double)(fskp->f_mark));
+#endif
 		else
 		    fprintf(stderr, "### CARRIER %.2f @ %.1f Hz ",
 			    (double)(bfsk_data_rate),
+#ifdef USE_FFT
 			    (double)(fskp->b_mark * fskp->band_width));
+#endif
+#ifdef USE_GOERTZEL
+			    (double)(fskp->f_mark));
+#endif
 	    }
 
 	    if ( !quiet_mode )


### PR DESCRIPTION
There you go!

generating the audio:
```
echo “HELLO” | ./minimodem --tx --ascii --startbits 0 --stopbits 0.0 -f minimodem_hello.wav 8
```

decoding the audio:
```
~/github/minimodem/src$ ./minimodem --rx --ascii --startbits 0 --stopbits 0.0 -f minimodem_hello.wav 8
### CARRIER 8.00 @ 1585.0 Hz ###
“HELLO”

### NOCARRIER ndata=12 confidence=8899.333 ampl=2999.792 bps=8.00 (rate perfect) ###
```

This 'should' close https://github.com/kamalmostafa/minimodem/issues/50 although this is just a quick implementation and I am sure you will want to refactor things a big

Also, note that that Goertzel function is returning the magnitude squared, I'd need a square root but it is not really necessary.

Thanks for this project though!