### PR TITLE
Include pulseaudio in macOS dependency list.

### DIFF
--- a/install-dependencies-macos.sh
+++ b/install-dependencies-macos.sh
@@ -5,3 +5,4 @@ set -o pipefail
 
 brew install libsndfile fftw autoconf libtool
 brew install automake || brew upgrade automake
+brew install pulseaudio


### PR DESCRIPTION
minimodem on macOS requires pulseaudio, which can be installed from brew.